### PR TITLE
Added platform name Envoy to config

### DIFF
--- a/Config.in
+++ b/Config.in
@@ -3,6 +3,7 @@ config DEMO_PLATFORM
 	default "coronet" if BR2_powerpc
 	default "dagger"  if BR2_arm
 	default "zero"    if BR2_x86_64
+	default "envoy"   if BR2_aarch64
 	default BR2_ARCH
 
 config DEMO_VENDOR_ID


### PR DESCRIPTION
To get the right name of the created executable we have to add a translation of BR2_aarch64 to envoy.

Signed-off-by: Andreas Egeberg <andreas.egeberg@westermo.com>